### PR TITLE
Add draft github workflow to run tests.

### DIFF
--- a/.github/workflows/crosswalk-tests.yml
+++ b/.github/workflows/crosswalk-tests.yml
@@ -1,0 +1,43 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+        include:
+          - python-version: "3.10"
+            coverage: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
In https://github.com/xborrat/medical-standard-voc-translator/pull/4 we added a draft testing framework. This pull request adds the tests to a github workflow. 

After the pull request is merged, pull requests will trigger the tests to be run on a GitHub server. The tests also include a step to check formatting with [flake8](https://flake8.pycqa.org/en/latest/).

The formatting checks will initially fail. We can refactor the code later so that they pass.