### PR TITLE
Removes vocab_list attribute as part of VocabTranslator Class.

### DIFF
--- a/crosswalk.py
+++ b/crosswalk.py
@@ -69,8 +69,6 @@ class VocabTranslator(object):
                               converters={"concept_id": str,
                                           "concept_code": str},
                               engine='python')
-        # List of all vocabularies in the diccionary
-        self.vocab_list = concept["vocabulary_id"].unique()
 
         # Concept relationship dictionary load.
         concept_rel = pd.read_csv(


### PR DESCRIPTION
This pull request removes attribute for list of unique vocab values within the VocabTranslator Class as this information is returned as part of the `def check_concept_file_source_target_values`.